### PR TITLE
Improve resource handling in ConfigReader

### DIFF
--- a/src/main/java/com/qa/utils/ConfigReader.java
+++ b/src/main/java/com/qa/utils/ConfigReader.java
@@ -8,12 +8,12 @@ public class ConfigReader {
     private static Properties properties;
 
     static {
-        try {
-            String filePath = "src/browser.properties";
-            FileInputStream fileInputStream = new FileInputStream(filePath);
+        String filePath = "src/browser.properties";
+        try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
             properties = new Properties();
             properties.load(fileInputStream);
         } catch (IOException e) {
+            System.err.println("Failed to load configuration from " + filePath + ": " + e.getMessage());
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
## Summary
- close `FileInputStream` using try-with-resources
- add detailed error message if properties file fails to load

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841792bb64c8320bc34927112edd899